### PR TITLE
fix: Attempt to fix compile error 'lifetime elid'

### DIFF
--- a/core/src/dynmod.rs
+++ b/core/src/dynmod.rs
@@ -29,7 +29,7 @@ fn flx_rs_score(source: &str, pattern: &str) -> Option<Vec<i32>> {
 ///
 /// (fn STR QUERY)
 #[defun]
-fn score(env: &Env, str: String, query: String) -> Result<Option<Vector>> {
+fn score(env: &Env, str: String, query: String) -> Result<Option<Vector<'_>>> {
     let _vec: Option<Vec<i32>> = flx_rs_score(&str, &query);
     if _vec == None {
         return Ok(None);


### PR DESCRIPTION
Log: https://github.com/jcs-elpa/flx-rs/actions/runs/17357000719/job/49271497016#step:5:69

```
error: hiding a lifetime that's elided elsewhere is confusing
Error:   --> src\dynmod.rs:32:15
   |
32 | fn score(env: &Env, str: String, query: String) -> Result<Option<Vector>> {
   |               ^^^^ the lifetime is elided here                   ------ the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
   |
32 | fn score(env: &Env, str: String, query: String) -> Result<Option<Vector<'_>>> {
   |                                                                        ++++

error: could not compile `flx_rs_core` (lib) due to 1 previous error
Error: Process completed with exit code 1.
```